### PR TITLE
Added support for Wayland wlroots compositors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Forked from [rofi-screenshot](https://github.com/danrog303/rofi-screenshot).
 
 ## Features
 1. Using rofi to display screenshot taking menu
-2. Allows to take screenshot of whole screen, only selected region (region can be selected using mouse), selected window (using mouse), or the currently active monitor.
-3. Saving image as JPG, PNG or copying screenshot to clipboard
+2. Allows to take screenshot of whole screen, only selected region (region can be selected using mouse)
+3. In the wayland version, screenshots can also be taken of selected window (using mouse), or the currently active monitor. 
+4. Saving image as JPG, PNG or copying screenshot to clipboard
 
 ## Dependencies
 Before you use this application, you need to install the following dependencies - either using your package manager (like apt, pacman) or by manually compiling source codes.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
-# rofi-screenshot
-> Script for taking screenshots on minimalist Linux distributions.
+# rofi-screenshot-wayland
+> Script for taking screenshots on wlroots based wayland compositors (such as Sway)
+
+Forked from [rofi-screenshot](https://github.com/danrog303/rofi-screenshot).
 
 ## Features
 1. Using rofi to display screenshot taking menu
-2. Allows to take screenshot of whole screen or only selected region (region can be selected using mouse)
+2. Allows to take screenshot of whole screen, only selected region (region can be selected using mouse), selected window (using mouse), or the currently active monitor.
 3. Saving image as JPG, PNG or copying screenshot to clipboard
 
 ## Dependencies
 Before you use this application, you need to install the following dependencies - either using your package manager (like apt, pacman) or by manually compiling source codes.
 
 - rofi (for displaying menus)
-- slop (for selecting screen regions)
-- ffcast (for saving screenshots of entire screen or specified region)
-- xclip (for copying image to clipboard)
-- libnotify (for sending desktop notifications)
+- grimshot (for taking the screenshot)
 - imagemagick (for converting screenshots to jpg)
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # rofi-screenshot-wayland
-> Script for taking screenshots on wlroots based wayland compositors (such as Sway)
+> Script for taking screenshots on minimalist Linux distributions. Now with support for wlroots based wayland compositors (such as Sway)
 
 Forked from [rofi-screenshot](https://github.com/danrog303/rofi-screenshot).
 

--- a/README.md
+++ b/README.md
@@ -11,16 +11,27 @@ Forked from [rofi-screenshot](https://github.com/danrog303/rofi-screenshot).
 ## Dependencies
 Before you use this application, you need to install the following dependencies - either using your package manager (like apt, pacman) or by manually compiling source codes.
 
+### Wayland
+The following dependencies are required for Wayland version:
 - rofi (for displaying menus)
 - grimshot (for taking the screenshot)
+- imagemagick (for converting screenshots to jpg)
+
+### Original
+The following are required for the X11 version:
+- rofi (for displaying menus)
+- slop (for selecting screen regions)
+- ffcast (for saving screenshots of entire screen or specified region)
+- xclip (for copying image to clipboard)
+- libnotify (for sending desktop notifications)
 - imagemagick (for converting screenshots to jpg)
 
 ## Usage
 1. Install required dependecies.
 2. Clone this repo
-3. Copy rofi-screenshot.sh to any directory in your $PATH environmental variable
-4. Give rofi-screenshot.sh execution rights by running `chmod a+x rofi-screenshot.sh`
-5. Run rofi-screenshot.sh to open screenshot taking tool (or assign the script to a keyboard shortcut to have it always at hand)
+3. Copy the desired script (`rofi-screenshot.sh` or `rofi-screenshot-wayland.sh`) to any directory in your $PATH environmental variable
+4. Give the script execution rights by running `chmod a+x rofi-screenshot.sh` or `chmod a+x rofi-screenshot-wayland.sh`
+5. Run the script to open screenshot taking tool (or assign the script to a keyboard shortcut to have it always at hand)
 
 ## Screenshots
 <img alt="Screenshot: rofi-screenshot" src="https://user-images.githubusercontent.com/32397526/148370014-757b1059-3dff-4509-80e0-5db7527eacba.png" width="400">

--- a/rofi-screenshot-wayland.sh
+++ b/rofi-screenshot-wayland.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/sh
+
+# CONFIG
+SAVE_DIR=$(xdg-user-dir PICTURES)
+# END CONFIG
+
+# LANGUAGE STRINGS
+lang_scr_whole="📷 Screenshot of whole screen (all monitors)"
+lang_scr_fragment="📷 Screenshot of selected region"
+lang_scr_window="📷 Screenshot of selected Window"
+lang_scr_output="📷 Screenshot of current monitor"
+
+lang_delay="⏰ Delay:"
+lang_nodelay="🕰 No delay"
+
+lang_save_png="🖼️ Save as png"
+lang_save_jpg="🖼️ Save as jpg"
+lang_copy_clipboard="🖼️ Copy to clipboard"
+
+lang_copied="Screenshot copied to clipboard"
+lang_saved="Screenshot saved to file"
+# END OF LANGUAGE STRINGS
+
+rofi_delay=$(
+    printf "%s \n%s 1s\n%s 3s\n%s 5s\n%s 10s\n%s" \
+           "$lang_nodelay" "$lang_delay" "$lang_delay" "$lang_delay" "$lang_delay" |
+    rofi -dmenu -p "screenshot" -lines 5
+) || exit 2
+
+rofi_save_method=$(
+    printf "%s\n%s\n%s\n" "$lang_copy_clipboard" "$lang_save_png" "$lang_save_jpg" |
+    rofi -dmenu -p "screenshot" -lines 3
+) || exit 3
+
+rofi_scr_type=$(
+    printf "%s\n%s\n"  "$lang_scr_fragment" "$lang_scr_whole" "$lang_scr_window" "$lang_scr_output"|
+    rofi -dmenu -p "screenshot" -lines 2
+) || exit 4
+
+#if [ "$rofi_scr_type" = "$lang_scr_fragment" ]; then
+#    screen_fragment=$(slop --highlight --tolerance=0 --color=0.3,0.4,0.6,0.4 -n -f '-g %g ')
+#fi
+
+if [ "$rofi_delay" = "$lang_delay 1s" ]; then
+    sleep 1
+elif [ "$rofi_delay" = "$lang_delay 3s" ]; then
+    sleep 3
+elif [ "$rofi_delay" = "$lang_delay 5s" ]; then
+    sleep 5
+elif [ "$rofi_delay" = "$lang_delay 10s" ]; then
+    sleep 10
+fi
+
+# check if the file should be saved as jpg or png, set "$filepath" accordingly
+filename="Screenshot $(date '+%Y-%m-%d, %R:%S')"
+if [ "$rofi_save_method" = "$lang_save_jpg" ]; then
+    filename="$filename.jpg"
+else
+    filename="$filename.png"
+fi
+filepath="$SAVE_DIR/$filename"
+tempfilepath="/tmp/$filename"
+
+# handle each option, calling the relevant grimshot command
+# Area screenshot
+# save: grimshot save area "$filepath"
+# copy: grimshot copy area
+if [ "$rofi_scr_type" = "$lang_scr_fragment" ] && [ "$rofi_save_method" = "$lang_copy_clipboard" ]; then
+    grimshot copy area
+elif [ "$rofi_scr_type" = "$lang_scr_fragment" ] && [ "$rofi_save_method" = "$lang_save_png" ]; then
+    grimshot save area "$filepath"
+elif [ "$rofi_scr_type" = "$lang_scr_fragment" ] && [ "$rofi_save_method" = "$lang_save_jpg" ]; then
+    grimshot save area "$filepath"
+    
+# Fullscreen screenshot
+# save: grimshot save screen "$filepath"
+# copy: grimshot copy screen
+elif [ "$rofi_scr_type" = "$lang_scr_whole" ] && [ "$rofi_save_method" = "$lang_copy_clipboard" ]; then
+    grimshot copy screen
+elif [ "$rofi_scr_type" = "$lang_scr_whole" ] && [ "$rofi_save_method" = "$lang_save_png" ]; then
+    grimshot save screen "$filepath"
+elif [ "$rofi_scr_type" = "$lang_scr_whole" ] && [ "$rofi_save_method" = "$lang_save_jpg" ]; then
+    grimshot save screen "$filepath"
+# Window Screenshot
+# save: grimshot save window "$filepath"
+# copy: grimshot copy window
+elif [ "$rofi_scr_type" = "$lang_scr_window" ] && [ "$rofi_save_method" = "$lang_copy_clipboard" ]; then
+    grimshot copy window
+elif [ "$rofi_scr_type" = "$lang_scr_window" ] && [ "$rofi_save_method" = "$lang_save_png" ]; then
+    grimshot save window "$filepath"
+elif [ "$rofi_scr_type" = "$lang_scr_window" ] && [ "$rofi_save_method" = "$lang_save_jpg" ]; then
+    grimshot save window "$filepath"
+# Current output screenshot
+# save: grimshot save output "$filepath"
+# copy: grimshot copy output
+elif [ "$rofi_scr_type" = "$lang_scr_output" ] && [ "$rofi_save_method" = "$lang_copy_clipboard" ]; then
+    grimshot copy output
+elif [ "$rofi_scr_type" = "$lang_scr_output" ] && [ "$rofi_save_method" = "$lang_save_png" ]; then
+    grimshot save output "$filepath"
+elif [ "$rofi_scr_type" = "$lang_scr_output" ] && [ "$rofi_save_method" = "$lang_save_jpg" ]; then
+    grimshot save output "$filepath"
+fi

--- a/rofi-screenshot.sh
+++ b/rofi-screenshot.sh
@@ -5,10 +5,8 @@ SAVE_DIR=$(xdg-user-dir PICTURES)
 # END CONFIG
 
 # LANGUAGE STRINGS
-lang_scr_whole="📷 Screenshot of whole screen (all monitors)"
+lang_scr_whole="📷 Screenshot of whole screen"
 lang_scr_fragment="📷 Screenshot of selected region"
-lang_scr_window="📷 Screenshot of selected Window"
-lang_scr_output="📷 Screenshot of current monitor"
 
 lang_delay="⏰ Delay:"
 lang_nodelay="🕰 No delay"
@@ -22,24 +20,24 @@ lang_saved="Screenshot saved to file"
 # END OF LANGUAGE STRINGS
 
 rofi_delay=$(
-    printf "%s \n%s 1s\n%s 3s\n%s 5s\n%s 10s\n%s" \
-           "$lang_nodelay" "$lang_delay" "$lang_delay" "$lang_delay" "$lang_delay" |
+    printf "%s 1s\n%s 3s\n%s 5s\n%s 10s\n%s\n" \
+           "$lang_delay" "$lang_delay" "$lang_delay" "$lang_delay" "$lang_nodelay" |
     rofi -dmenu -p "screenshot" -lines 5
 ) || exit 2
 
 rofi_save_method=$(
-    printf "%s\n%s\n%s\n" "$lang_copy_clipboard" "$lang_save_png" "$lang_save_jpg" |
+    printf "%s\n%s\n%s\n" "$lang_save_png" "$lang_save_jpg" "$lang_copy_clipboard" |
     rofi -dmenu -p "screenshot" -lines 3
 ) || exit 3
 
 rofi_scr_type=$(
-    printf "%s\n%s\n"  "$lang_scr_fragment" "$lang_scr_whole" "$lang_scr_window" "$lang_scr_output"|
+    printf "%s\n%s\n" "$lang_scr_whole" "$lang_scr_fragment" |
     rofi -dmenu -p "screenshot" -lines 2
 ) || exit 4
 
-#if [ "$rofi_scr_type" = "$lang_scr_fragment" ]; then
-#    screen_fragment=$(slop --highlight --tolerance=0 --color=0.3,0.4,0.6,0.4 -n -f '-g %g ')
-#fi
+if [ "$rofi_scr_type" = "$lang_scr_fragment" ]; then
+    screen_fragment=$(slop --highlight --tolerance=0 --color=0.3,0.4,0.6,0.4 -n -f '-g %g ')
+fi
 
 if [ "$rofi_delay" = "$lang_delay 1s" ]; then
     sleep 1
@@ -51,52 +49,27 @@ elif [ "$rofi_delay" = "$lang_delay 10s" ]; then
     sleep 10
 fi
 
-# check if the file should be saved as jpg or png, set "$filepath" accordingly
 filename="Screenshot $(date '+%Y-%m-%d, %R:%S')"
-if [ "$rofi_save_method" = "$lang_save_jpg" ]; then
-    filename="$filename.jpg"
-else
-    filename="$filename.png"
-fi
-filepath="$SAVE_DIR/$filename"
-tempfilepath="/tmp/$filename"
+filepath="$SAVE_DIR/$filename.png"
+tempfilepath="/tmp/$filename.png"
 
-# handle each option, calling the relevant grimshot command
-# Area screenshot
-# save: grimshot save area "$filepath"
-# copy: grimshot copy area
-if [ "$rofi_scr_type" = "$lang_scr_fragment" ] && [ "$rofi_save_method" = "$lang_copy_clipboard" ]; then
-    grimshot copy area
-elif [ "$rofi_scr_type" = "$lang_scr_fragment" ] && [ "$rofi_save_method" = "$lang_save_png" ]; then
-    grimshot save area "$filepath"
-elif [ "$rofi_scr_type" = "$lang_scr_fragment" ] && [ "$rofi_save_method" = "$lang_save_jpg" ]; then
-    grimshot save area "$filepath"
-    
-# Fullscreen screenshot
-# save: grimshot save screen "$filepath"
-# copy: grimshot copy screen
-elif [ "$rofi_scr_type" = "$lang_scr_whole" ] && [ "$rofi_save_method" = "$lang_copy_clipboard" ]; then
-    grimshot copy screen
-elif [ "$rofi_scr_type" = "$lang_scr_whole" ] && [ "$rofi_save_method" = "$lang_save_png" ]; then
-    grimshot save screen "$filepath"
-elif [ "$rofi_scr_type" = "$lang_scr_whole" ] && [ "$rofi_save_method" = "$lang_save_jpg" ]; then
-    grimshot save screen "$filepath"
-# Window Screenshot
-# save: grimshot save window "$filepath"
-# copy: grimshot copy window
-elif [ "$rofi_scr_type" = "$lang_scr_window" ] && [ "$rofi_save_method" = "$lang_copy_clipboard" ]; then
-    grimshot copy window
-elif [ "$rofi_scr_type" = "$lang_scr_window" ] && [ "$rofi_save_method" = "$lang_save_png" ]; then
-    grimshot save window "$filepath"
-elif [ "$rofi_scr_type" = "$lang_scr_window" ] && [ "$rofi_save_method" = "$lang_save_jpg" ]; then
-    grimshot save window "$filepath"
-# Current output screenshot
-# save: grimshot save output "$filepath"
-# copy: grimshot copy output
-elif [ "$rofi_scr_type" = "$lang_scr_output" ] && [ "$rofi_save_method" = "$lang_copy_clipboard" ]; then
-    grimshot copy output
-elif [ "$rofi_scr_type" = "$lang_scr_output" ] && [ "$rofi_save_method" = "$lang_save_png" ]; then
-    grimshot save output "$filepath"
-elif [ "$rofi_scr_type" = "$lang_scr_output" ] && [ "$rofi_save_method" = "$lang_save_jpg" ]; then
-    grimshot save output "$filepath"
+if [ "$rofi_scr_type" = "$lang_scr_fragment" ]; then
+    ffcast -q "$screen_fragment" png "$tempfilepath"
+else
+    ffcast -q png "$tempfilepath"
 fi
+
+
+if [ "$rofi_save_method" = "$lang_copy_clipboard" ]; then
+    xclip -selection clipboard -t "image/png" "$tempfilepath"
+    notify-send "$lang_copied"
+elif [ "$rofi_save_method" = "$lang_save_jpg" ]; then
+    convert "/tmp/$filename.png" "/tmp/$filename.jpg"
+    cp "/tmp/$filename.jpg" "$SAVE_DIR"
+    notify-send "$lang_saved" "$SAVE_DIR/$filename.jpg"
+else
+    cp "$tempfilepath" "$filepath"
+    notify-send "$lang_saved" "$SAVE_DIR/$filename.png"
+fi
+
+rm "$tempfilepath"


### PR DESCRIPTION
Nice script, I have added a wayland version of the script that makes use of `grimshot`, so that it can be used on wlroots compositors such as Sway. 
The original script has been kept, and the wayland version is a separate script called `rofi-screenshot-wayland.sh`, the README has been updated to reflect this. 